### PR TITLE
0.3.1: fix Postgres and MySQL migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,36 @@ jobs:
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/rivet_cms_ci
         run: cd spec/dummy && bin/rails db:migrate
+
+  # MySQL (InnoDB) also enforces foreign keys at DDL time and rejects some
+  # things SQLite and Postgres accept (e.g. defaults on JSON columns), so it
+  # gets its own migration run. Uses trilogy: no libmysqlclient to build.
+  migrations-mysql:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: rivet_cms_ci
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+
+      - name: Run engine migrations on MySQL
+        env:
+          DATABASE_URL: trilogy://root:root@127.0.0.1:3306/rivet_cms_ci
+        run: cd spec/dummy && bin/rails db:migrate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,5 +103,5 @@ jobs:
 
       - name: Run engine migrations on MySQL
         env:
-          DATABASE_URL: trilogy://root:root@127.0.0.1:3306/rivet_cms_ci
+          DATABASE_URL: trilogy://root:root@127.0.0.1:3306/rivet_cms_ci?encoding=utf8mb4
         run: cd spec/dummy && bin/rails db:migrate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,37 @@ jobs:
 
       - name: Run tests
         run: bundle exec rspec
+
+  # The dummy app runs on SQLite, which does not enforce foreign keys at DDL
+  # time, so it hides migration-ordering bugs that break on Postgres. This job
+  # runs the engine's migrations against real Postgres to catch them.
+  migrations-postgres:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: rivet_cms_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+
+      - name: Run engine migrations on Postgres
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/rivet_cms_ci
+        run: cd spec/dummy && bin/rails db:migrate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to RivetCMS are documented here. While the version is
 below 1.0, minor releases may include breaking changes; each one is listed
 under a Breaking heading.
 
+## 0.3.1 - 2026-08-09
+
+### Fixed
+- Migrations aborted on PostgreSQL: the components table declared a foreign key
+  to `rivet_cms_categories` before that table was created. SQLite tolerated it;
+  Postgres did not. The foreign key is now added after both tables exist.
+
 ## 0.3.0 - 2026-08-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ under a Breaking heading.
 ## 0.3.1 - 2026-08-09
 
 ### Fixed
-- Migrations aborted on PostgreSQL: the components table declared a foreign key
-  to `rivet_cms_categories` before that table was created. SQLite tolerated it;
-  Postgres did not. The foreign key is now added after both tables exist.
+- Migrations aborted on PostgreSQL and MySQL. Two issues SQLite tolerated but
+  stricter databases did not: the components table declared a foreign key to
+  `rivet_cms_categories` before that table existed (now added afterward), and
+  the fields table set a default on a JSON column, which MySQL rejects (the
+  default now lives on the model). Migrations are exercised against Postgres
+  and MySQL in CI.
 
 ## 0.3.0 - 2026-08-09
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,5 @@ gem "rubocop-rails-omakase", require: false
 
 group :test do
   gem "pg"
+  gem "trilogy"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,7 @@ gem "rubocop-rails-omakase", require: false
 
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"
+
+group :test do
+  gem "pg"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,6 +322,8 @@ GEM
     stringio (3.1.8)
     thor (1.4.0)
     timeout (0.4.4)
+    trilogy (2.12.6)
+      bigdecimal
     tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -355,6 +357,7 @@ DEPENDENCIES
   rspec-rails (~> 6.0)
   rubocop-rails-omakase
   sqlite3
+  trilogy
 
 BUNDLED WITH
    2.7.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rivet_cms (0.3.0)
+    rivet_cms (0.3.1)
       bcrypt (~> 3.1.7)
       image_processing (~> 1.14)
       inertia_rails (~> 3.0)
@@ -189,6 +189,13 @@ GEM
     parser (3.3.10.0)
       ast (~> 2.4.1)
       racc
+    pg (1.6.3)
+    pg (1.6.3-aarch64-linux)
+    pg (1.6.3-aarch64-linux-musl)
+    pg (1.6.3-arm64-darwin)
+    pg (1.6.3-x86_64-darwin)
+    pg (1.6.3-x86_64-linux)
+    pg (1.6.3-x86_64-linux-musl)
     pp (0.6.3)
       prettyprint
     prefixed_ids (1.8.1)
@@ -341,6 +348,7 @@ PLATFORMS
 
 DEPENDENCIES
   factory_bot_rails (~> 6.2)
+  pg
   propshaft
   puma
   rivet_cms!

--- a/app/models/rivet_cms/field.rb
+++ b/app/models/rivet_cms/field.rb
@@ -9,6 +9,10 @@ module RivetCms
     belongs_to :component, optional: true
     has_many :content_values, dependent: :destroy
 
+    # Defaulted here rather than in the DB, since MySQL rejects defaults on
+    # JSON columns; keeps config a hash regardless of adapter.
+    attribute :config, default: -> { {} }
+
     enum :field_type, {
       string: 0,
       text: 1,

--- a/db/migrate/20251121020625_create_rivet_cms_components.rb
+++ b/db/migrate/20251121020625_create_rivet_cms_components.rb
@@ -4,7 +4,10 @@ class CreateRivetCmsComponents < ActiveRecord::Migration[7.0]
       t.string :name, null: false, index: true
       t.string :slug, null: false
       t.text :description
-      t.references :category, foreign_key: { to_table: :rivet_cms_categories }
+      # The FK is added in the categories migration, which runs later; adding
+      # it here would reference a table that does not exist yet (fine on
+      # SQLite, fatal on Postgres).
+      t.references :category
       t.references :organization, foreign_key: { to_table: :rivet_cms_organizations }, null: false
       t.timestamps
 

--- a/db/migrate/20251121040115_create_rivet_cms_categories.rb
+++ b/db/migrate/20251121040115_create_rivet_cms_categories.rb
@@ -10,5 +10,8 @@ class CreateRivetCmsCategories < ActiveRecord::Migration[7.0]
       t.timestamps
       t.index [ :organization_id, :slug ], unique: true
     end
+
+    # Deferred from the components migration, which runs before this table exists
+    add_foreign_key :rivet_cms_components, :rivet_cms_categories, column: :category_id
   end
 end

--- a/db/migrate/20260119185946_create_content_system_tables.rb
+++ b/db/migrate/20260119185946_create_content_system_tables.rb
@@ -11,7 +11,9 @@ class CreateContentSystemTables < ActiveRecord::Migration[7.0]
       t.boolean :required, default: false, null: false
       t.integer :min_items
       t.integer :max_items
-      t.json :config, default: {}
+      # No DB default: MySQL rejects defaults on JSON columns. The Field model
+      # defaults it to {} instead.
+      t.json :config
       t.integer :position, default: 0, null: false
       t.integer :row, default: 0, null: false
       t.string :width, default: "full", null: false

--- a/lib/rivet_cms/version.rb
+++ b/lib/rivet_cms/version.rb
@@ -1,3 +1,3 @@
 module RivetCms
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,6 +11,9 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -40,7 +43,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
   end
 
   create_table "rivet_cms_api_tokens", force: :cascade do |t|
-    t.integer "organization_id", null: false
+    t.bigint "organization_id", null: false
     t.string "name", null: false
     t.string "token_digest", null: false
     t.string "token_last4", null: false
@@ -58,7 +61,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.string "slug", null: false
     t.integer "position", default: 0, null: false
     t.boolean "system", default: false, null: false
-    t.integer "organization_id", null: false
+    t.bigint "organization_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_rivet_cms_categories_on_name"
@@ -68,9 +71,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
 
   create_table "rivet_cms_component_instances", force: :cascade do |t|
     t.string "owner_type", null: false
-    t.integer "owner_id", null: false
-    t.integer "field_id", null: false
-    t.integer "component_id", null: false
+    t.bigint "owner_id", null: false
+    t.bigint "field_id", null: false
+    t.bigint "component_id", null: false
     t.integer "position", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -83,8 +86,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.string "name", null: false
     t.string "slug", null: false
     t.text "description"
-    t.integer "category_id"
-    t.integer "organization_id", null: false
+    t.bigint "category_id"
+    t.bigint "organization_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["category_id"], name: "index_rivet_cms_components_on_category_id"
@@ -98,7 +101,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.string "slug", null: false
     t.text "description"
     t.boolean "single", default: false
-    t.integer "organization_id", null: false
+    t.bigint "organization_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
@@ -110,8 +113,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
 
   create_table "rivet_cms_content_values", force: :cascade do |t|
     t.string "owner_type", null: false
-    t.integer "owner_id", null: false
-    t.integer "field_id", null: false
+    t.bigint "owner_id", null: false
+    t.bigint "field_id", null: false
     t.string "string_value"
     t.text "text_value"
     t.integer "integer_value"
@@ -122,18 +125,18 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.json "json_value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "media_asset_id"
+    t.bigint "media_asset_id"
     t.index ["field_id"], name: "index_rivet_cms_content_values_on_field_id"
     t.index ["media_asset_id"], name: "index_rivet_cms_content_values_on_media_asset_id"
     t.index ["owner_type", "owner_id", "field_id"], name: "idx_content_values_owner_field", unique: true
   end
 
   create_table "rivet_cms_document_revisions", force: :cascade do |t|
-    t.integer "document_id", null: false
+    t.bigint "document_id", null: false
     t.string "locale", default: "en", null: false
     t.integer "schema_version", default: 1, null: false
     t.string "author_type"
-    t.integer "author_id"
+    t.bigint "author_id"
     t.string "author_name"
     t.integer "state", default: 0, null: false
     t.datetime "published_at"
@@ -146,8 +149,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
   end
 
   create_table "rivet_cms_documents", force: :cascade do |t|
-    t.integer "organization_id", null: false
-    t.integer "content_type_id", null: false
+    t.bigint "organization_id", null: false
+    t.bigint "content_type_id", null: false
     t.string "slug", null: false
     t.string "singleton_key"
     t.bigint "published_revision_id"
@@ -165,9 +168,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
   end
 
   create_table "rivet_cms_fields", force: :cascade do |t|
-    t.integer "organization_id", null: false
-    t.integer "content_type_id"
-    t.integer "component_id"
+    t.bigint "organization_id", null: false
+    t.bigint "content_type_id"
+    t.bigint "component_id"
     t.string "key", null: false
     t.string "label", null: false
     t.integer "field_type", default: 0, null: false
@@ -192,7 +195,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
   end
 
   create_table "rivet_cms_media_assets", force: :cascade do |t|
-    t.integer "organization_id", null: false
+    t.bigint "organization_id", null: false
     t.string "filename"
     t.string "content_type"
     t.bigint "byte_size"
@@ -219,9 +222,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
 
   create_table "rivet_cms_relations", force: :cascade do |t|
     t.string "owner_type", null: false
-    t.integer "owner_id", null: false
-    t.integer "field_id", null: false
-    t.integer "target_document_id", null: false
+    t.bigint "owner_id", null: false
+    t.bigint "field_id", null: false
+    t.bigint "target_document_id", null: false
     t.integer "position", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -231,7 +234,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
   end
 
   create_table "rivet_cms_users", force: :cascade do |t|
-    t.integer "organization_id", null: false
+    t.bigint "organization_id", null: false
     t.string "name", null: false
     t.string "email", null: false
     t.string "password_digest"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,10 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
-
-  create_table "active_storage_attachments", force: :cascade do |t|
+  create_table "active_storage_attachments", charset: "latin1", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
     t.bigint "record_id", null: false
@@ -24,7 +21,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", force: :cascade do |t|
+  create_table "active_storage_blobs", charset: "latin1", force: :cascade do |t|
     t.string "key", null: false
     t.string "filename", null: false
     t.string "content_type"
@@ -36,13 +33,13 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "active_storage_variant_records", force: :cascade do |t|
+  create_table "active_storage_variant_records", charset: "latin1", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table "rivet_cms_api_tokens", force: :cascade do |t|
+  create_table "rivet_cms_api_tokens", charset: "latin1", force: :cascade do |t|
     t.bigint "organization_id", null: false
     t.string "name", null: false
     t.string "token_digest", null: false
@@ -56,7 +53,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["token_digest"], name: "index_rivet_cms_api_tokens_on_token_digest", unique: true
   end
 
-  create_table "rivet_cms_categories", force: :cascade do |t|
+  create_table "rivet_cms_categories", charset: "latin1", force: :cascade do |t|
     t.string "name", null: false
     t.string "slug", null: false
     t.integer "position", default: 0, null: false
@@ -69,7 +66,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["organization_id"], name: "index_rivet_cms_categories_on_organization_id"
   end
 
-  create_table "rivet_cms_component_instances", force: :cascade do |t|
+  create_table "rivet_cms_component_instances", charset: "latin1", force: :cascade do |t|
     t.string "owner_type", null: false
     t.bigint "owner_id", null: false
     t.bigint "field_id", null: false
@@ -82,7 +79,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["owner_type", "owner_id", "field_id", "position"], name: "idx_cmpi_owner_field_pos"
   end
 
-  create_table "rivet_cms_components", force: :cascade do |t|
+  create_table "rivet_cms_components", charset: "latin1", force: :cascade do |t|
     t.string "name", null: false
     t.string "slug", null: false
     t.text "description"
@@ -96,7 +93,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["organization_id"], name: "index_rivet_cms_components_on_organization_id"
   end
 
-  create_table "rivet_cms_content_types", force: :cascade do |t|
+  create_table "rivet_cms_content_types", charset: "latin1", force: :cascade do |t|
     t.string "name", null: false
     t.string "slug", null: false
     t.text "description"
@@ -111,7 +108,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["organization_id"], name: "index_rivet_cms_content_types_on_organization_id"
   end
 
-  create_table "rivet_cms_content_values", force: :cascade do |t|
+  create_table "rivet_cms_content_values", charset: "latin1", force: :cascade do |t|
     t.string "owner_type", null: false
     t.bigint "owner_id", null: false
     t.bigint "field_id", null: false
@@ -131,7 +128,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["owner_type", "owner_id", "field_id"], name: "idx_content_values_owner_field", unique: true
   end
 
-  create_table "rivet_cms_document_revisions", force: :cascade do |t|
+  create_table "rivet_cms_document_revisions", charset: "latin1", force: :cascade do |t|
     t.bigint "document_id", null: false
     t.string "locale", default: "en", null: false
     t.integer "schema_version", default: 1, null: false
@@ -148,7 +145,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["document_id"], name: "index_rivet_cms_document_revisions_on_document_id"
   end
 
-  create_table "rivet_cms_documents", force: :cascade do |t|
+  create_table "rivet_cms_documents", charset: "latin1", force: :cascade do |t|
     t.bigint "organization_id", null: false
     t.bigint "content_type_id", null: false
     t.string "slug", null: false
@@ -167,7 +164,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["published_revision_id"], name: "index_rivet_cms_documents_on_published_revision_id"
   end
 
-  create_table "rivet_cms_fields", force: :cascade do |t|
+  create_table "rivet_cms_fields", charset: "latin1", force: :cascade do |t|
     t.bigint "organization_id", null: false
     t.bigint "content_type_id"
     t.bigint "component_id"
@@ -178,7 +175,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.boolean "required", default: false, null: false
     t.integer "min_items"
     t.integer "max_items"
-    t.json "config", default: {}
+    t.json "config"
     t.integer "position", default: 0, null: false
     t.integer "row", default: 0, null: false
     t.string "width", default: "full", null: false
@@ -194,7 +191,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["position"], name: "index_rivet_cms_fields_on_position"
   end
 
-  create_table "rivet_cms_media_assets", force: :cascade do |t|
+  create_table "rivet_cms_media_assets", charset: "latin1", force: :cascade do |t|
     t.bigint "organization_id", null: false
     t.string "filename"
     t.string "content_type"
@@ -208,7 +205,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["organization_id"], name: "index_rivet_cms_media_assets_on_organization_id"
   end
 
-  create_table "rivet_cms_organizations", force: :cascade do |t|
+  create_table "rivet_cms_organizations", charset: "latin1", force: :cascade do |t|
     t.string "name", null: false
     t.string "domain", null: false
     t.string "subdomain"
@@ -220,7 +217,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["subdomain"], name: "index_rivet_cms_organizations_on_subdomain"
   end
 
-  create_table "rivet_cms_relations", force: :cascade do |t|
+  create_table "rivet_cms_relations", charset: "latin1", force: :cascade do |t|
     t.string "owner_type", null: false
     t.bigint "owner_id", null: false
     t.bigint "field_id", null: false
@@ -233,7 +230,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["target_document_id"], name: "index_rivet_cms_relations_on_target_document_id"
   end
 
-  create_table "rivet_cms_users", force: :cascade do |t|
+  create_table "rivet_cms_users", charset: "latin1", force: :cascade do |t|
     t.bigint "organization_id", null: false
     t.string "name", null: false
     t.string "email", null: false
@@ -245,7 +242,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["organization_id"], name: "index_rivet_cms_users_on_organization_id"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", charset: "latin1", force: :cascade do |t|
     t.string "name"
     t.string "email"
     t.datetime "created_at", null: false

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
-  create_table "active_storage_attachments", charset: "latin1", force: :cascade do |t|
+  create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
     t.bigint "record_id", null: false
@@ -21,7 +21,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", charset: "latin1", force: :cascade do |t|
+  create_table "active_storage_blobs", force: :cascade do |t|
     t.string "key", null: false
     t.string "filename", null: false
     t.string "content_type"
@@ -33,14 +33,14 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "active_storage_variant_records", charset: "latin1", force: :cascade do |t|
+  create_table "active_storage_variant_records", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table "rivet_cms_api_tokens", charset: "latin1", force: :cascade do |t|
-    t.bigint "organization_id", null: false
+  create_table "rivet_cms_api_tokens", force: :cascade do |t|
+    t.integer "organization_id", null: false
     t.string "name", null: false
     t.string "token_digest", null: false
     t.string "token_last4", null: false
@@ -53,12 +53,12 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["token_digest"], name: "index_rivet_cms_api_tokens_on_token_digest", unique: true
   end
 
-  create_table "rivet_cms_categories", charset: "latin1", force: :cascade do |t|
+  create_table "rivet_cms_categories", force: :cascade do |t|
     t.string "name", null: false
     t.string "slug", null: false
     t.integer "position", default: 0, null: false
     t.boolean "system", default: false, null: false
-    t.bigint "organization_id", null: false
+    t.integer "organization_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_rivet_cms_categories_on_name"
@@ -66,11 +66,11 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["organization_id"], name: "index_rivet_cms_categories_on_organization_id"
   end
 
-  create_table "rivet_cms_component_instances", charset: "latin1", force: :cascade do |t|
+  create_table "rivet_cms_component_instances", force: :cascade do |t|
     t.string "owner_type", null: false
-    t.bigint "owner_id", null: false
-    t.bigint "field_id", null: false
-    t.bigint "component_id", null: false
+    t.integer "owner_id", null: false
+    t.integer "field_id", null: false
+    t.integer "component_id", null: false
     t.integer "position", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -79,12 +79,12 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["owner_type", "owner_id", "field_id", "position"], name: "idx_cmpi_owner_field_pos"
   end
 
-  create_table "rivet_cms_components", charset: "latin1", force: :cascade do |t|
+  create_table "rivet_cms_components", force: :cascade do |t|
     t.string "name", null: false
     t.string "slug", null: false
     t.text "description"
-    t.bigint "category_id"
-    t.bigint "organization_id", null: false
+    t.integer "category_id"
+    t.integer "organization_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["category_id"], name: "index_rivet_cms_components_on_category_id"
@@ -93,12 +93,12 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["organization_id"], name: "index_rivet_cms_components_on_organization_id"
   end
 
-  create_table "rivet_cms_content_types", charset: "latin1", force: :cascade do |t|
+  create_table "rivet_cms_content_types", force: :cascade do |t|
     t.string "name", null: false
     t.string "slug", null: false
     t.text "description"
     t.boolean "single", default: false
-    t.bigint "organization_id", null: false
+    t.integer "organization_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
@@ -108,10 +108,10 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["organization_id"], name: "index_rivet_cms_content_types_on_organization_id"
   end
 
-  create_table "rivet_cms_content_values", charset: "latin1", force: :cascade do |t|
+  create_table "rivet_cms_content_values", force: :cascade do |t|
     t.string "owner_type", null: false
-    t.bigint "owner_id", null: false
-    t.bigint "field_id", null: false
+    t.integer "owner_id", null: false
+    t.integer "field_id", null: false
     t.string "string_value"
     t.text "text_value"
     t.integer "integer_value"
@@ -122,18 +122,18 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.json "json_value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "media_asset_id"
+    t.integer "media_asset_id"
     t.index ["field_id"], name: "index_rivet_cms_content_values_on_field_id"
     t.index ["media_asset_id"], name: "index_rivet_cms_content_values_on_media_asset_id"
     t.index ["owner_type", "owner_id", "field_id"], name: "idx_content_values_owner_field", unique: true
   end
 
-  create_table "rivet_cms_document_revisions", charset: "latin1", force: :cascade do |t|
-    t.bigint "document_id", null: false
+  create_table "rivet_cms_document_revisions", force: :cascade do |t|
+    t.integer "document_id", null: false
     t.string "locale", default: "en", null: false
     t.integer "schema_version", default: 1, null: false
     t.string "author_type"
-    t.bigint "author_id"
+    t.integer "author_id"
     t.string "author_name"
     t.integer "state", default: 0, null: false
     t.datetime "published_at"
@@ -145,9 +145,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["document_id"], name: "index_rivet_cms_document_revisions_on_document_id"
   end
 
-  create_table "rivet_cms_documents", charset: "latin1", force: :cascade do |t|
-    t.bigint "organization_id", null: false
-    t.bigint "content_type_id", null: false
+  create_table "rivet_cms_documents", force: :cascade do |t|
+    t.integer "organization_id", null: false
+    t.integer "content_type_id", null: false
     t.string "slug", null: false
     t.string "singleton_key"
     t.bigint "published_revision_id"
@@ -164,10 +164,10 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["published_revision_id"], name: "index_rivet_cms_documents_on_published_revision_id"
   end
 
-  create_table "rivet_cms_fields", charset: "latin1", force: :cascade do |t|
-    t.bigint "organization_id", null: false
-    t.bigint "content_type_id"
-    t.bigint "component_id"
+  create_table "rivet_cms_fields", force: :cascade do |t|
+    t.integer "organization_id", null: false
+    t.integer "content_type_id"
+    t.integer "component_id"
     t.string "key", null: false
     t.string "label", null: false
     t.integer "field_type", default: 0, null: false
@@ -191,8 +191,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["position"], name: "index_rivet_cms_fields_on_position"
   end
 
-  create_table "rivet_cms_media_assets", charset: "latin1", force: :cascade do |t|
-    t.bigint "organization_id", null: false
+  create_table "rivet_cms_media_assets", force: :cascade do |t|
+    t.integer "organization_id", null: false
     t.string "filename"
     t.string "content_type"
     t.bigint "byte_size"
@@ -205,7 +205,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["organization_id"], name: "index_rivet_cms_media_assets_on_organization_id"
   end
 
-  create_table "rivet_cms_organizations", charset: "latin1", force: :cascade do |t|
+  create_table "rivet_cms_organizations", force: :cascade do |t|
     t.string "name", null: false
     t.string "domain", null: false
     t.string "subdomain"
@@ -217,11 +217,11 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["subdomain"], name: "index_rivet_cms_organizations_on_subdomain"
   end
 
-  create_table "rivet_cms_relations", charset: "latin1", force: :cascade do |t|
+  create_table "rivet_cms_relations", force: :cascade do |t|
     t.string "owner_type", null: false
-    t.bigint "owner_id", null: false
-    t.bigint "field_id", null: false
-    t.bigint "target_document_id", null: false
+    t.integer "owner_id", null: false
+    t.integer "field_id", null: false
+    t.integer "target_document_id", null: false
     t.integer "position", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -230,8 +230,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["target_document_id"], name: "index_rivet_cms_relations_on_target_document_id"
   end
 
-  create_table "rivet_cms_users", charset: "latin1", force: :cascade do |t|
-    t.bigint "organization_id", null: false
+  create_table "rivet_cms_users", force: :cascade do |t|
+    t.integer "organization_id", null: false
     t.string "name", null: false
     t.string "email", null: false
     t.string "password_digest"
@@ -242,7 +242,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_000001) do
     t.index ["organization_id"], name: "index_rivet_cms_users_on_organization_id"
   end
 
-  create_table "users", charset: "latin1", force: :cascade do |t|
+  create_table "users", force: :cascade do |t|
     t.string "name"
     t.string "email"
     t.datetime "created_at", null: false


### PR DESCRIPTION
Fixes migrations aborting on Postgres (reported) and MySQL.

- FK ordering: `components` referenced `rivet_cms_categories` before it existed. SQLite tolerates this at DDL time, Postgres/MySQL don't. FK now added after both tables exist.
- MySQL rejects a default on the `fields.config` JSON column; moved that default to the model (`attribute :config, default: -> { {} }`).

Verified locally on real Postgres and MySQL. Adds CI jobs that run the migrations against both (MySQL via trilogy, no libmysqlclient build).