### PR TITLE
0.4.0: sort entries by numeric, string, and enumeration fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to RivetCMS are documented here. While the version is
 below 1.0, minor releases may include breaking changes; each one is listed
 under a Breaking heading.
 
+## Unreleased
+
+### Added
+- Entries can be sorted by integer, decimal, string, and enumeration field
+  keys in the delivery API and the Ruby helpers (previously only date and
+  datetime fields). String and enumeration sorts are case-insensitive.
+
 ## 0.3.1 - 2026-08-09
 
 ### Fixed

--- a/app/services/rivet_cms/content_query.rb
+++ b/app/services/rivet_cms/content_query.rb
@@ -113,7 +113,11 @@ module RivetCms
       # Case-insensitive for string-backed fields: binary collations (SQLite)
       # would otherwise sort every capitalized value before every lowercase one
       column = "LOWER(#{column})" if column.end_with?(".string_value")
-      scope.joins(field_join(field, "cv_sort")).order(Arel.sql("#{column} #{direction}"))
+      # Entries without the field come back NULL through the left join, and
+      # the databases disagree on where NULLs sort; pin them last in either
+      # direction. The id tiebreaker keeps pagination stable on equal values.
+      scope.joins(field_join(field, "cv_sort"))
+           .order(Arel.sql("(#{column} IS NULL), #{column} #{direction}, rivet_cms_documents.id"))
     end
 
     def sortable_field(key)

--- a/app/services/rivet_cms/content_query.rb
+++ b/app/services/rivet_cms/content_query.rb
@@ -9,6 +9,15 @@ module RivetCms
     DEFAULT_PER_PAGE = 25
     MAX_PER_PAGE = 100
     DOCUMENT_SORTS = { "created_at" => :created_at, "updated_at" => :updated_at, "slug" => :slug }.freeze
+    # Custom field types that can be sorted on, with the value column each
+    # one lives in. Filters stay date-only. Long-text types are deliberately
+    # excluded: sorting on unbounded blobs is never intended and MySQL cannot
+    # sort TEXT without prefix filesorts.
+    SORTABLE_VALUE_COLUMNS = {
+      "date" => "date_value", "datetime" => "datetime_value",
+      "integer" => "integer_value", "decimal" => "decimal_value",
+      "string" => "string_value", "enumeration" => "string_value"
+    }.freeze
 
     def initialize(content_type, sort: nil, filters: {}, page: nil, per_page: nil, populate: nil, fields: nil)
       @content_type = content_type
@@ -97,10 +106,18 @@ module RivetCms
           .order(Arel.sql("pub.published_at #{direction}"))
       end
 
-      field = date_field(key)
+      field = sortable_field(key)
       raise Error, "unknown sort field: #{key}" if field.nil?
 
-      scope.joins(field_join(field, "cv_sort")).order(Arel.sql("cv_sort.#{date_column(field)} #{direction}"))
+      column = "cv_sort.#{SORTABLE_VALUE_COLUMNS.fetch(field.field_type)}"
+      # Case-insensitive for string-backed fields: binary collations (SQLite)
+      # would otherwise sort every capitalized value before every lowercase one
+      column = "LOWER(#{column})" if column.end_with?(".string_value")
+      scope.joins(field_join(field, "cv_sort")).order(Arel.sql("#{column} #{direction}"))
+    end
+
+    def sortable_field(key)
+      @content_type.fields.kept.find_by(key: key, field_type: SORTABLE_VALUE_COLUMNS.keys)
     end
 
     def filtered(scope)

--- a/app/services/rivet_cms/open_api_generator.rb
+++ b/app/services/rivet_cms/open_api_generator.rb
@@ -62,7 +62,7 @@ module RivetCms
         { name: "page", in: "query", schema: { type: "integer", default: 1 } },
         { name: "per_page", in: "query", schema: { type: "integer", default: 25, maximum: 100 } },
         { name: "sort", in: "query", schema: { type: "string" },
-          description: "Field/column, prefix - for descending (e.g. -published_at)." },
+          description: "Field/column, prefix - for descending (e.g. -published_at). Columns created_at/updated_at/slug/published_at, or the key of a date, datetime, integer, decimal, string, or enumeration field. String sorts are case-insensitive." },
         populate_param,
         fields_param
       ]

--- a/spec/lib/rivet_cms/content_helpers_spec.rb
+++ b/spec/lib/rivet_cms/content_helpers_spec.rb
@@ -38,6 +38,17 @@ module RivetCms
         expect(list.first.title).to start_with("Post")
       end
 
+      it "sorts by an integer field key" do
+        order_field = create(:field, field_type: :integer, key: "nav_order", content_type: posts, organization: organization)
+        [ [ "second", 2 ], [ "first", 1 ] ].each do |slug, value|
+          document = publish(posts, slug: slug)
+          document.published_revision.content_values.create!(field: order_field, integer_value: value)
+        end
+
+        expect(RivetCms.entries("posts", organization: organization, sort: "nav_order").map(&:slug)).to eq(%w[first second])
+        expect(RivetCms.entries("posts", organization: organization, sort: "-nav_order").map(&:slug)).to eq(%w[second first])
+      end
+
       it "populates references into nested entries" do
         jane = publish(authors, slug: "jane", values: { name_field => "Jane" })
         publish(posts, slug: "hello", values: { title_field => "Hi" }, relations: { author_field => jane })

--- a/spec/services/rivet_cms/content_query_spec.rb
+++ b/spec/services/rivet_cms/content_query_spec.rb
@@ -26,18 +26,18 @@ module RivetCms
       expect(docs.limit_value).to eq(100)
     end
 
-    it "sorts by an integer field key in both directions" do
+    it "sorts by an integer field key, entries without the field last in both directions" do
       order_field = create(:field, field_type: :integer, key: "nav_order", content_type: content_type, organization: organization)
-      [ [ "second", 2 ], [ "first", 1 ] ].each do |slug, value|
+      [ [ "second", 2 ], [ "first", 1 ], [ "unordered", nil ] ].each do |slug, value|
         document = create(:document, slug: slug, content_type: content_type, organization: organization)
         draft = create(:document_revision, document: document, state: :draft)
         document.update!(draft_revision: draft)
-        draft.content_values.create!(field: order_field, integer_value: value)
+        draft.content_values.create!(field: order_field, integer_value: value) if value
         draft.publish!
       end
 
-      expect(described_class.new(content_type, sort: "nav_order").documents.map(&:slug)).to eq(%w[first second])
-      expect(described_class.new(content_type, sort: "-nav_order").documents.map(&:slug)).to eq(%w[second first])
+      expect(described_class.new(content_type, sort: "nav_order").documents.map(&:slug)).to eq(%w[first second unordered])
+      expect(described_class.new(content_type, sort: "-nav_order").documents.map(&:slug)).to eq(%w[second first unordered])
     end
 
     it "sorts by a string field key case-insensitively, excluding long-text types" do

--- a/spec/services/rivet_cms/content_query_spec.rb
+++ b/spec/services/rivet_cms/content_query_spec.rb
@@ -26,6 +26,35 @@ module RivetCms
       expect(docs.limit_value).to eq(100)
     end
 
+    it "sorts by an integer field key in both directions" do
+      order_field = create(:field, field_type: :integer, key: "nav_order", content_type: content_type, organization: organization)
+      [ [ "second", 2 ], [ "first", 1 ] ].each do |slug, value|
+        document = create(:document, slug: slug, content_type: content_type, organization: organization)
+        draft = create(:document_revision, document: document, state: :draft)
+        document.update!(draft_revision: draft)
+        draft.content_values.create!(field: order_field, integer_value: value)
+        draft.publish!
+      end
+
+      expect(described_class.new(content_type, sort: "nav_order").documents.map(&:slug)).to eq(%w[first second])
+      expect(described_class.new(content_type, sort: "-nav_order").documents.map(&:slug)).to eq(%w[second first])
+    end
+
+    it "sorts by a string field key case-insensitively, excluding long-text types" do
+      body_field = create(:field, field_type: :text, key: "body", content_type: content_type, organization: organization)
+      [ [ "banana", "Banana" ], [ "apple", "apple" ] ].each do |slug, title|
+        document = create(:document, slug: slug, content_type: content_type, organization: organization)
+        draft = create(:document_revision, document: document, state: :draft)
+        document.update!(draft_revision: draft)
+        draft.content_values.create!(field: title_field, string_value: title)
+        draft.publish!
+      end
+
+      expect(described_class.new(content_type, sort: "title").documents.map(&:slug)).to eq(%w[apple banana])
+      expect { described_class.new(content_type, sort: body_field.key).documents }
+        .to raise_error(ContentQuery::Error, /unknown sort field/)
+    end
+
     it "raises on an unknown sort field" do
       expect {
         described_class.new(content_type, sort: "bogus").documents


### PR DESCRIPTION
The delivery API and Ruby helpers could only sort by date/datetime custom fields (plus the built-in columns). This lets `sort=` take the key of any integer, decimal, string, or enumeration field, in both directions.

- String/enumeration sorts are case-insensitive (`LOWER`), so binary collations don't order every capitalized value first.
- `text`/`rich_text`/`markdown` stay unsortable deliberately.
- Specs at three levels: ContentQuery, plus a `RivetCms.entries(sort:)` helper spec proving the Ruby side shares the whitelist.
- OpenAPI sort description now enumerates the sortable set.

Semver: minor, ships as 0.4.0.