### PR TITLE
Delivery API no longer inherits config.parent_controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ under a Breaking heading.
   keys in the delivery API and the Ruby helpers (previously only date and
   datetime fields). String and enumeration sorts are case-insensitive.
 
+### Fixed
+- The delivery API no longer inherits from `config.parent_controller`, so a
+  host admin base class with its own before_actions, layouts, or rescue_from
+  handlers can no longer break API responses. Only the admin UI inherits the
+  host parent.
+
 ## 0.3.1 - 2026-08-09
 
 ### Fixed

--- a/app/controllers/concerns/rivet_cms/resolves_organization.rb
+++ b/app/controllers/concerns/rivet_cms/resolves_organization.rb
@@ -1,0 +1,21 @@
+module RivetCms
+  # Host-based organization lookup, shared by the admin controllers and the
+  # delivery API's public mode (token mode resolves from the token instead).
+  module ResolvesOrganization
+    private
+
+    def set_current_organization
+      RivetCms::Current.organization =
+        Organization.find_by(domain: request.host) ||
+        Organization.find_by(domain: "localhost") ||
+        Organization.first ||
+        default_organization
+    end
+
+    def default_organization
+      return unless Rails.env.development? || Rails.env.test?
+
+      Organization.create!(name: "Development Org", domain: "localhost", subdomain: "dev")
+    end
+  end
+end

--- a/app/controllers/rivet_cms/application_controller.rb
+++ b/app/controllers/rivet_cms/application_controller.rb
@@ -1,8 +1,12 @@
 module RivetCms
   # Inherits from the host-configured parent controller so host auth filters and
   # helpers are available. Do not reference this class from initializers — the
-  # parent is resolved when Zeitwerk first loads it.
+  # parent is resolved when Zeitwerk first loads it. Admin controllers only:
+  # the delivery API inherits DeliveryBaseController, so host filters never
+  # reach it.
   class ApplicationController < RivetCms.parent_controller.constantize
+    include ResolvesOrganization
+
     layout "rivet_cms/application"
 
     # Organization first: built-in authentication scopes its user lookup to it
@@ -204,20 +208,6 @@ module RivetCms
 
     def effective_logout_path
       RivetCms.builtin_auth? ? logout_path : RivetCms.logout_path
-    end
-
-    def set_current_organization
-      RivetCms::Current.organization =
-        Organization.find_by(domain: request.host) ||
-        Organization.find_by(domain: "localhost") ||
-        Organization.first ||
-        default_organization
-    end
-
-    def default_organization
-      return unless Rails.env.development? || Rails.env.test?
-
-      Organization.create!(name: "Development Org", domain: "localhost", subdomain: "dev")
     end
   end
 end

--- a/app/controllers/rivet_cms/content_controller.rb
+++ b/app/controllers/rivet_cms/content_controller.rb
@@ -1,12 +1,5 @@
 module RivetCms
-  class ContentController < ApplicationController
-    # The read API is token-gated (or public when RivetCms.public_api), so host
-    # admin auth/CSRF must not run, and the org comes from the token, not the host.
-    skip_before_action :authenticate_rivet_user
-    skip_before_action :set_rivet_current_user
-    skip_before_action :set_current_organization
-    skip_after_action :set_csrf_cookie
-
+  class ContentController < DeliveryBaseController
     before_action :resolve_api_access
 
     def index

--- a/app/controllers/rivet_cms/delivery_base_controller.rb
+++ b/app/controllers/rivet_cms/delivery_base_controller.rb
@@ -5,5 +5,11 @@ module RivetCms
   # the token, or from the request host in public mode.
   class DeliveryBaseController < ActionController::Base
     include ResolvesOrganization
+
+    # TODO: the delivery API is GET-only, so the CSRF protection inherited
+    # from ActionController::Base never runs. If a write endpoint is ever
+    # added here, disable it for this base (protect_from_forgery with:
+    # :null_session): API clients authenticate with bearer tokens, not
+    # session cookies, and would otherwise be rejected with 422s.
   end
 end

--- a/app/controllers/rivet_cms/delivery_base_controller.rb
+++ b/app/controllers/rivet_cms/delivery_base_controller.rb
@@ -1,0 +1,9 @@
+module RivetCms
+  # Deliberately independent of the host-configured parent_controller: the
+  # delivery API is token-gated JSON, so host auth filters, layouts, and
+  # rescue_from handlers must never apply to it. The organization comes from
+  # the token, or from the request host in public mode.
+  class DeliveryBaseController < ActionController::Base
+    include ResolvesOrganization
+  end
+end

--- a/spec/requests/rivet_cms/delivery_api_spec.rb
+++ b/spec/requests/rivet_cms/delivery_api_spec.rb
@@ -38,6 +38,14 @@ module RivetCms
         # A host admin base class with its own before_actions, layouts, or
         # rescue_from handlers must never affect API responses, so the
         # delivery controllers may not descend from the re-parented admin base.
+        #
+        # TODO: only this half of the contract is automated. The other half,
+        # that a configured parent_controller DOES re-parent the admin and run
+        # host filters there, is exercised only by the RIVET_HOST_AUTH=1 dev
+        # demo, because the parent is baked in when the engine classes load
+        # and cannot be swapped per-example. Before promoting BYO auth to real
+        # users, add coverage that boots the dummy with a host parent (e.g. a
+        # separate CI job running the suite with RIVET_HOST_AUTH set).
         expect(ContentController.superclass).to eq(RivetCms::DeliveryBaseController)
         expect(RivetCms::DeliveryBaseController.superclass).to eq(ActionController::Base)
         expect(ContentController.ancestors).not_to include(RivetCms::ApplicationController)

--- a/spec/requests/rivet_cms/delivery_api_spec.rb
+++ b/spec/requests/rivet_cms/delivery_api_spec.rb
@@ -34,6 +34,15 @@ module RivetCms
         expect(response).to have_http_status(:ok)
       end
 
+      it "stays outside the host parent_controller inheritance chain" do
+        # A host admin base class with its own before_actions, layouts, or
+        # rescue_from handlers must never affect API responses, so the
+        # delivery controllers may not descend from the re-parented admin base.
+        expect(ContentController.superclass).to eq(RivetCms::DeliveryBaseController)
+        expect(RivetCms::DeliveryBaseController.superclass).to eq(ActionController::Base)
+        expect(ContentController.ancestors).not_to include(RivetCms::ApplicationController)
+      end
+
       it "200s with a valid token" do
         token = ApiToken.generate!(name: "CI", organization: organization)
         content_type


### PR DESCRIPTION
A host pointing `config.parent_controller` at an admin base class (e.g. `Admin::BaseController` with `before_action :require_admin!`) would run those filters, plus layouts and `rescue_from` handlers, on the token-gated delivery API, breaking it in ways the engine's `skip_before_action` list can't anticipate.

- `ContentController` now inherits a fixed `DeliveryBaseController < ActionController::Base`; the host parent applies to admin controllers only.
- Shared host-based org resolution extracted to `ResolvesOrganization` (admin controllers + the API's public mode).
- Structural spec pins the boundary (the suite runs with the default parent, so inheritance is asserted directly).

Fix-class; rides in the Unreleased 0.4.0 changelog.